### PR TITLE
Fix base model parsing in modelfile utils

### DIFF
--- a/backend/open_webui/test/util/test_misc.py
+++ b/backend/open_webui/test/util/test_misc.py
@@ -1,0 +1,11 @@
+from open_webui.utils.misc import parse_ollama_modelfile
+
+
+def test_parse_base_model_with_special_chars():
+    model_text = """FROM phi3:mini-4k-instruct
+PARAMETER temperature 0.7
+"""
+    info = parse_ollama_modelfile(model_text)
+    assert info["base_model_id"] == "phi3:mini-4k-instruct"
+    assert info["params"]["temperature"] == 0.7
+

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -387,7 +387,7 @@ def parse_ollama_modelfile(model_text):
 
     # Parse base model
     base_model_match = re.search(
-        r"^FROM\s+(\w+)", model_text, re.MULTILINE | re.IGNORECASE
+        r"^FROM\s+(\S+)", model_text, re.MULTILINE | re.IGNORECASE
     )
     if base_model_match:
         data["base_model_id"] = base_model_match.group(1)


### PR DESCRIPTION
## Summary
- allow hyphens and colons when parsing the base model id from an Ollama Modelfile
- add regression test for `parse_ollama_modelfile`

## Testing
- `PYTHONPATH=backend pytest backend/open_webui/test/util/test_misc.py -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_683f9f465e688333be04a778a1d0fc9f